### PR TITLE
TimeLogRunning sub Riblet들 테스트 추가

### DIFF
--- a/iTime/Domain/Sources/Entities/Timer/TimerInfo.swift
+++ b/iTime/Domain/Sources/Entities/Timer/TimerInfo.swift
@@ -10,9 +10,18 @@ import AppFoundation
 
 // MARK: - TimerInfo
 
-public struct TimerInfo: PropertyBuilderCompatible {
+public struct TimerInfo: PropertyBuilderCompatible, Equatable {
   public var lastlyForegroundTrackedDate: Date = Date()
   public var currentDate: Date = Date()
   public var runningTime: Int = Int()
   public var startTime: Int = Int()
+  
+  public init(lastlyForegroundTrackedDate: Date, currentDate: Date, runningTime: Int, startTime: Int) {
+    self.lastlyForegroundTrackedDate = lastlyForegroundTrackedDate
+    self.currentDate = currentDate
+    self.runningTime = runningTime
+    self.startTime = startTime
+  }
+  
+  public init() {}
 }

--- a/iTime/Domain/Sources/UsecaseTestSupports/UsecaseMock/TimeUsecaseMock.swift
+++ b/iTime/Domain/Sources/UsecaseTestSupports/UsecaseMock/TimeUsecaseMock.swift
@@ -23,8 +23,10 @@ public class TimerUsecaseMock: TimerUsecase {
   }
   
   public var finishCallCount: Int = 0
+  public var activityValue: Activity = .empty
   public func finish(_ activity: Entities.Activity) -> RxSwift.Observable<Void> {
     finishCallCount += 1
+    activityValue = activity
     return .just(Void())
   }
   

--- a/iTime/Feature/Package.swift
+++ b/iTime/Feature/Package.swift
@@ -96,6 +96,7 @@ let package = Package(
         "StartImpl",
         "Editor",
         "EditorImpl",
+        .product(name: "RIBsTestSupport", package: "ProxyPackage"),
       ]),
     .target(
       name: "LoggedIn",

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/ActivityDatePicker/ActivityDatePickerInteractableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/ActivityDatePicker/ActivityDatePickerInteractableSpy.swift
@@ -1,0 +1,19 @@
+//
+//  File.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import Start
+import StartImpl
+import RIBsTestSupport
+
+public class ActivityDatePickerInteractableSpy:
+  InteractableMock,
+  ActivityDatePickerInteractable {
+  public var routerSetCallCounter: Int = 0
+  public var router: Start.ActivityDatePickerRouting? { didSet { self.routerSetCallCounter += 1 } }
+  public var listenerSetCallCounter: Int = 0
+  public var listener: Start.ActivityDatePickerListener? { didSet { self.listenerSetCallCounter += 1 }}
+}

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/ActivityDatePicker/ActivityDatePickerListenerSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/ActivityDatePicker/ActivityDatePickerListenerSpy.swift
@@ -5,9 +5,8 @@
 //  Created by 이상헌 on 1/2/24.
 //
 
-import Foundation
 import Start
 
-public final class CurrentActivityListenerSpy: CurrentActivityListener {
+public final class ActivityDatePickerListenerSpy: ActivityDatePickerListener {
   public init() {}
 }

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/ActivityDatePicker/ActivityDatePickerPresentableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/ActivityDatePicker/ActivityDatePickerPresentableSpy.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import StartImpl
+
+public final class ActivityDatePickerPresentableSpy: ActivityDatePickerPresentable {
+  public var listenerSetCallCount: Int = 0
+  public var listener: StartImpl.ActivityDatePickerPresentableListener? { didSet { self.listenerSetCallCount += 1 }}
+  public init() {}
+}

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/ActivityDatePicker/ActivityDatePickerViewControllableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/ActivityDatePicker/ActivityDatePickerViewControllableSpy.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import RIBs
+
+import StartImpl
+import RIBsTestSupport
+
+public class ActivityDatePickerViewControllableSpy:
+  ViewControllableMock,
+  ActivityDatePickerViewControllable 
+{
+    
+}

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentActivity/CurrentActivityInteractableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentActivity/CurrentActivityInteractableSpy.swift
@@ -1,0 +1,20 @@
+//
+//  File.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import RIBsTestSupport
+import StartImpl
+import Start
+
+public class CurrentActivityInteractableSpy:
+  InteractableMock,
+  CurrentActivityInteractable
+{
+  public var routerSetCallCount: Int = 0
+  public var router: CurrentActivityRouting? { didSet { self.routerSetCallCount += 1 }}
+  public var listenerSetCallCount: Int = 0
+  public var listener: CurrentActivityListener? { didSet { self.listenerSetCallCount += 1 }}
+}

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentActivity/CurrentActivityPresentableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentActivity/CurrentActivityPresentableSpy.swift
@@ -11,13 +11,11 @@ public final class CurrentActivityPresentableSpy: CurrentActivityPresentable {
   public var listenerSetCallCount: Int = 0
   public var listener: StartImpl.CurrentActivityPresentableListener? { didSet { self.listenerSetCallCount += 1 }}
   
-  public var bindTageViewTitleHandler: (()->())?
   public var bindTagViewTitleCallCount: Int = 0
   public var bindTagViewTitleSetValue: String = String()
   public func bindTageViewTitle(_ title: String) {
     bindTagViewTitleCallCount += 1
     bindTagViewTitleSetValue = title
-    bindTageViewTitleHandler?()
   }
   
   public init() {}

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentActivity/CurrentActivityPresentableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentActivity/CurrentActivityPresentableSpy.swift
@@ -11,11 +11,13 @@ public final class CurrentActivityPresentableSpy: CurrentActivityPresentable {
   public var listenerSetCallCount: Int = 0
   public var listener: StartImpl.CurrentActivityPresentableListener? { didSet { self.listenerSetCallCount += 1 }}
   
+  public var bindTageViewTitleHandler: (()->())?
   public var bindTagViewTitleCallCount: Int = 0
   public var bindTagViewTitleSetValue: String = String()
   public func bindTageViewTitle(_ title: String) {
     bindTagViewTitleCallCount += 1
     bindTagViewTitleSetValue = title
+    bindTageViewTitleHandler?()
   }
   
   public init() {}

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentActivity/CurrentActivityViewControllableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentActivity/CurrentActivityViewControllableSpy.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import RIBs
+
+import StartImpl
+import RIBsTestSupport
+
+public class CurrentActivityViewControllableSpy:
+  ViewControllableMock,
+  CurrentActivityViewControllable
+{
+  
+}

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentTimerTime/CurrentTimerTimeInteractableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentTimerTime/CurrentTimerTimeInteractableSpy.swift
@@ -1,0 +1,9 @@
+//
+//  File.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import Foundation
+

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentTimerTime/CurrentTimerTimeListenerSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentTimerTime/CurrentTimerTimeListenerSpy.swift
@@ -8,6 +8,6 @@
 import Foundation
 import Start
 
-public final class CurrentActivityListenerSpy: CurrentActivityListener {
+public class CurrentTimerTimeListenerSpy: CurrentTimerTimeListener {
   public init() {}
 }

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentTimerTime/CurrentTimerTimePresentableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentTimerTime/CurrentTimerTimePresentableSpy.swift
@@ -11,11 +11,14 @@ public class CurrentTimerTimePresentableSpy: CurrentTimerTimePresentable {
   public var listenerSetCallCount: Int = 0
   public var listener: StartImpl.CurrentTimerTimePresentableListener? { didSet { self.listenerSetCallCount += 1}}
   
+  
+  public var currentRunningTimeHandler: (() -> ())?
   public var currentRunningTimeCallCount: Int = 0
   public var currentRunningTimeSetValue: String = String()
   public func currentRunningTime(_ time: String) {
     currentRunningTimeCallCount += 1
     currentRunningTimeSetValue = time
+    currentRunningTimeHandler?()
   }
   
   public init() {}

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentTimerTime/CurrentTimerTimePresentableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentTimerTime/CurrentTimerTimePresentableSpy.swift
@@ -11,14 +11,11 @@ public class CurrentTimerTimePresentableSpy: CurrentTimerTimePresentable {
   public var listenerSetCallCount: Int = 0
   public var listener: StartImpl.CurrentTimerTimePresentableListener? { didSet { self.listenerSetCallCount += 1}}
   
-  
-  public var currentRunningTimeHandler: (() -> ())?
   public var currentRunningTimeCallCount: Int = 0
   public var currentRunningTimeSetValue: String = String()
   public func currentRunningTime(_ time: String) {
     currentRunningTimeCallCount += 1
     currentRunningTimeSetValue = time
-    currentRunningTimeHandler?()
   }
   
   public init() {}

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentTimerTime/CurrentTimerTimePresentableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/CurrentTimerTime/CurrentTimerTimePresentableSpy.swift
@@ -1,0 +1,22 @@
+//
+//  File.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import StartImpl
+
+public class CurrentTimerTimePresentableSpy: CurrentTimerTimePresentable {
+  public var listenerSetCallCount: Int = 0
+  public var listener: StartImpl.CurrentTimerTimePresentableListener? { didSet { self.listenerSetCallCount += 1}}
+  
+  public var currentRunningTimeCallCount: Int = 0
+  public var currentRunningTimeSetValue: String = String()
+  public func currentRunningTime(_ time: String) {
+    currentRunningTimeCallCount += 1
+    currentRunningTimeSetValue = time
+  }
+  
+  public init() {}
+}

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/TimerOperation/TimerOperationListenerSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/TimerOperation/TimerOperationListenerSpy.swift
@@ -8,9 +8,12 @@
 import Start
 
 public class TimerOperationListenerSpy: TimerOperationListener {
+  
+  public var detachTimeLogRunningHandler: (()->())?
   public var detachTimeLogRunningRIBCallCount: Int = 0
   public func detachTimeLogRunningRIB() {
     detachTimeLogRunningRIBCallCount += 1
+    detachTimeLogRunningHandler?()
   }
   public init() {}
 }

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/TimerOperation/TimerOperationListenerSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/TimerOperation/TimerOperationListenerSpy.swift
@@ -9,11 +9,9 @@ import Start
 
 public class TimerOperationListenerSpy: TimerOperationListener {
   
-  public var detachTimeLogRunningHandler: (()->())?
   public var detachTimeLogRunningRIBCallCount: Int = 0
   public func detachTimeLogRunningRIB() {
     detachTimeLogRunningRIBCallCount += 1
-    detachTimeLogRunningHandler?()
   }
   public init() {}
 }

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/TimerOperation/TimerOperationListenerSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/TimerOperation/TimerOperationListenerSpy.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import Start
+
+public class TimerOperationListenerSpy: TimerOperationListener {
+  public var detachTimeLogRunningRIBCallCount: Int = 0
+  public func detachTimeLogRunningRIB() {
+    detachTimeLogRunningRIBCallCount += 1
+  }
+  public init() {}
+}

--- a/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/TimerOperation/TimerOperationPresentableSpy.swift
+++ b/iTime/Feature/Sources/FeatureTestSupports/Start/Spies/TimeLogRunning/TimerOperation/TimerOperationPresentableSpy.swift
@@ -1,0 +1,23 @@
+//
+//  File.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import StartImpl
+
+public class TimerOperationPresentableSpy: TimerOperationPresentable {
+  
+  public var listenerSetCallCount: Int = 0
+  public var listener: StartImpl.TimerOperationPresentableListener? { didSet { self.listenerSetCallCount += 1}}
+  
+  public var isTimeRunningCallCount: Int = 0
+  public var isTimeRunningSetValue: Bool = false
+  public func isTimeRunning(_ isRunning: Bool) {
+    isTimeRunningCallCount += 1
+    isTimeRunningSetValue = isRunning
+  }
+  
+  public init() {}
+}

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/ActivityDatePicker/ActivityDatePickerInteractor.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/ActivityDatePicker/ActivityDatePickerInteractor.swift
@@ -12,7 +12,7 @@ import Start
 
 // MARK: - ActivityDatePickerPresentable
 
-protocol ActivityDatePickerPresentable: Presentable {
+public protocol ActivityDatePickerPresentable: Presentable {
   var listener: ActivityDatePickerPresentableListener? { get set }
 }
 

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/ActivityDatePicker/ActivityDatePickerRouter.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/ActivityDatePicker/ActivityDatePickerRouter.swift
@@ -11,14 +11,14 @@ import Start
 
 // MARK: - ActivityDatePickerInteractable
 
-protocol ActivityDatePickerInteractable: Interactable {
+public protocol ActivityDatePickerInteractable: Interactable {
   var router: ActivityDatePickerRouting? { get set }
   var listener: ActivityDatePickerListener? { get set }
 }
 
 // MARK: - ActivityDatePickerViewControllable
 
-protocol ActivityDatePickerViewControllable: ViewControllable {
+public protocol ActivityDatePickerViewControllable: ViewControllable {
 }
 
 // MARK: - ActivityDatePickerRouter

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/ActivityDatePicker/ActivityDatePickerViewController.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/ActivityDatePicker/ActivityDatePickerViewController.swift
@@ -15,7 +15,7 @@ import AppFoundation
 
 // MARK: - ActivityDatePickerPresentableListener
 
-protocol ActivityDatePickerPresentableListener: AnyObject {
+public protocol ActivityDatePickerPresentableListener: AnyObject {
 }
 
 // MARK: - ActivityDatePickerViewController

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentActivity/CurrentActivityInteractor.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentActivity/CurrentActivityInteractor.swift
@@ -48,8 +48,8 @@ final class CurrentActivityInteractor:
       .activityLogStream
       .map(\.title)
       .take(1)
-      .asDriver(onErrorDriveWith: .empty())
-      .drive(with: self) { owner, title in
+      .observe(on: MainScheduler.asyncInstance)
+      .subscribe(with: self) { owner, title in
         owner.presenter.bindTageViewTitle(title ?? "내가 지금 할 것은...")
       }
       .disposeOnDeactivate(interactor: self)

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentActivity/CurrentActivityInteractor.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentActivity/CurrentActivityInteractor.swift
@@ -31,14 +31,17 @@ final class CurrentActivityInteractor:
   weak var listener: CurrentActivityListener?
   
   private let activityLogModelStream: ActivityLogModelStream
+  private let observationScheduler: SchedulerType
   
   // MARK: - Initialization & DeInitialization
   
   init(
     presenter: CurrentActivityPresentable,
-    activityLogModelStream: ActivityLogModelStream
+    activityLogModelStream: ActivityLogModelStream,
+    observationScheduler: SchedulerType = MainScheduler.asyncInstance
   ) {
     self.activityLogModelStream = activityLogModelStream
+    self.observationScheduler = observationScheduler
     super.init(presenter: presenter)
     presenter.listener = self
   }
@@ -48,12 +51,11 @@ final class CurrentActivityInteractor:
       .activityLogStream
       .map(\.title)
       .take(1)
-      .observe(on: MainScheduler.asyncInstance)
+      .observe(on: observationScheduler)
       .subscribe(with: self) { owner, title in
         owner.presenter.bindTageViewTitle(title ?? "내가 지금 할 것은...")
       }
       .disposeOnDeactivate(interactor: self)
   }
-  
   
 }

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentActivity/CurrentActivityRouter.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentActivity/CurrentActivityRouter.swift
@@ -11,14 +11,14 @@ import Start
 
 // MARK: - CurrentActivityInteractable
 
-protocol CurrentActivityInteractable: Interactable {
+public protocol CurrentActivityInteractable: Interactable {
   var router: CurrentActivityRouting? { get set }
   var listener: CurrentActivityListener? { get set }
 }
 
 // MARK: - CurrentActivityViewControllable
 
-protocol CurrentActivityViewControllable: ViewControllable {
+public protocol CurrentActivityViewControllable: ViewControllable {
 }
 
 // MARK: - CurrentActivityRouter

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentTimerTime/CurrentTimerTimeInteractor.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentTimerTime/CurrentTimerTimeInteractor.swift
@@ -13,7 +13,7 @@ import Start
 
 // MARK: - CurrentTimerTimePresentable
 
-protocol CurrentTimerTimePresentable: Presentable {
+public protocol CurrentTimerTimePresentable: Presentable {
   var listener: CurrentTimerTimePresentableListener? { get set }
   func currentRunningTime(_ time: String)
 }
@@ -47,14 +47,14 @@ final class CurrentTimerTimeInteractor:
   func loadCurrentTime() {
     timerInfoModelDataStream.timerInfoModelDataStream
       .map(\.runningTime)
-      .asDriver(onErrorDriveWith: .empty())
-      .drive(with: self) { owner, time in
+      .observe(on: MainScheduler.asyncInstance)
+      .subscribe(with: self) { owner, time in
         owner.presenter.currentRunningTime(owner.timeString(time))
       }
       .disposeOnDeactivate(interactor: self)
   }
   
-  func timeString(_ time: Int) -> String {
+  private func timeString(_ time: Int) -> String {
       let hours = time / 3600
       let minutes = time / 60 % 60
       let seconds = time % 60

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentTimerTime/CurrentTimerTimeInteractor.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentTimerTime/CurrentTimerTimeInteractor.swift
@@ -32,14 +32,17 @@ final class CurrentTimerTimeInteractor:
   weak var listener: CurrentTimerTimeListener?
   
   private let timerInfoModelDataStream: TimerInfoModelDataStream
+  private let observationScheduler: SchedulerType
   
   // MARK: - Initialization & DeInitialization
   
   init(
     presenter: CurrentTimerTimePresentable,
-    timerInfoModelDataStream: TimerInfoModelDataStream
+    timerInfoModelDataStream: TimerInfoModelDataStream,
+    observationScheduler: SchedulerType = MainScheduler.asyncInstance
   ) {
     self.timerInfoModelDataStream = timerInfoModelDataStream
+    self.observationScheduler = observationScheduler
     super.init(presenter: presenter)
     presenter.listener = self
   }
@@ -47,7 +50,7 @@ final class CurrentTimerTimeInteractor:
   func loadCurrentTime() {
     timerInfoModelDataStream.timerInfoModelDataStream
       .map(\.runningTime)
-      .observe(on: MainScheduler.asyncInstance)
+      .observe(on: observationScheduler)
       .subscribe(with: self) { owner, time in
         owner.presenter.currentRunningTime(owner.timeString(time))
       }

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentTimerTime/CurrentTimerTimeViewController.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/CurrentTimerTime/CurrentTimerTimeViewController.swift
@@ -14,7 +14,7 @@ import SharedUI
 
 // MARK: - CurrentTimerTimePresentableListener
 
-protocol CurrentTimerTimePresentableListener: AnyObject {
+public protocol CurrentTimerTimePresentableListener: AnyObject {
   func loadCurrentTime()
 }
 

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/TimerOperation/TimerOperationInteractor.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/TimerOperation/TimerOperationInteractor.swift
@@ -14,7 +14,7 @@ import Start
 
 // MARK: - TimerOperationPresentable
 
-protocol TimerOperationPresentable: Presentable {
+public protocol TimerOperationPresentable: Presentable {
   var listener: TimerOperationPresentableListener? { get set }
   func isTimeRunning(_ isRunning: Bool)
 }

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/TimerOperation/TimerOperationInteractor.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/TimerOperation/TimerOperationInteractor.swift
@@ -62,10 +62,11 @@ final class TimerOperationInteractor:
     activityLogModelStream.activityLogStream
       .map(Activity.toActivity(_:))
       .flatMap(timerUsecase.finish)
+      .withUnretained(self)
+      .map { owner, _ in owner.listener?.detachTimeLogRunningRIB() }
       .take(1)
-      .subscribe(with: self) { owner, _ in
-        owner.listener?.detachTimeLogRunningRIB()
-      }
+      .debug("shlee")
+      .subscribe()
       .disposeOnDeactivate(interactor: self)
   }
   

--- a/iTime/Feature/Sources/StartImpl/TimeLogRunning/TimerOperation/TimerOperationViewController.swift
+++ b/iTime/Feature/Sources/StartImpl/TimeLogRunning/TimerOperation/TimerOperationViewController.swift
@@ -14,7 +14,7 @@ import SharedUI
 
 // MARK: - TimerOperationPresentableListener
 
-protocol TimerOperationPresentableListener: AnyObject {
+public protocol TimerOperationPresentableListener: AnyObject {
   func didTapStartButton()
   func didTapPauseButton()
   func didTapStopButton()

--- a/iTime/Feature/Tests/StartImplTests/LogEntryCreation/BookmarkList/BookmarkListInteractorTests.swift
+++ b/iTime/Feature/Tests/StartImplTests/LogEntryCreation/BookmarkList/BookmarkListInteractorTests.swift
@@ -67,10 +67,10 @@ final class BookmarkListInteractorTests: XCTestCase {
     let dummyBookmarks = DummyData.DummyBookmark.dummyBookmarksFour
     bookmarkModelDataStream.update(with: dummyBookmarks)
     sut.loadBookmarkList()
-    async let _ = bookmarkModelDataStream.bookmarks.values
     
     // When
     let result = sut.numberOfItems()
+    async let _ = bookmarkModelDataStream.bookmarks.values
     
     // Then
     XCTAssertEqual(result, dummyBookmarks.count)
@@ -81,10 +81,10 @@ final class BookmarkListInteractorTests: XCTestCase {
     let dummyBookmarks = DummyData.DummyBookmark.dummyBookmarksFour
     bookmarkModelDataStream.update(with: dummyBookmarks)
     sut.loadBookmarkList()
-    async let _ = bookmarkModelDataStream.bookmarks.values
     
     // When
     let bookmarkTitle = sut.bookmark(at: 0)
+    async let _ = bookmarkModelDataStream.bookmarks.values
     
     // Then
     XCTAssertEqual(bookmarkTitle, dummyBookmarks[0].title)

--- a/iTime/Feature/Tests/StartImplTests/TimeLogRunning/ActivityDatePicker/ActivityDatePickerInteractorTests.swift
+++ b/iTime/Feature/Tests/StartImplTests/TimeLogRunning/ActivityDatePicker/ActivityDatePickerInteractorTests.swift
@@ -1,0 +1,34 @@
+//
+//  ActivityDatePickerTests.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import XCTest
+import FeatureTestSupports
+@testable import StartImpl
+
+final class ActivityDatePickerInteractorTests: XCTestCase {
+  
+  private var sut: ActivityDatePickerInteractor!
+  private var activityDatePickerPresenter: ActivityDatePickerPresentableSpy!
+  private var activityDatePickerListener: ActivityDatePickerListenerSpy!
+
+  override func setUp() {
+    activityDatePickerPresenter = ActivityDatePickerPresentableSpy()
+    activityDatePickerListener = ActivityDatePickerListenerSpy()
+    sut = ActivityDatePickerInteractor(presenter: activityDatePickerPresenter)
+    sut.listener = activityDatePickerListener
+  }
+  
+  func test_activate() {
+    // When
+    sut.activate()
+    
+    // Then
+    XCTAssertTrue(sut.isActive)
+    XCTAssertEqual(activityDatePickerPresenter.listenerSetCallCount, 1)
+  }
+
+}

--- a/iTime/Feature/Tests/StartImplTests/TimeLogRunning/CurrentActivity/CurrentActivityInteractorTests.swift
+++ b/iTime/Feature/Tests/StartImplTests/TimeLogRunning/CurrentActivity/CurrentActivityInteractorTests.swift
@@ -37,19 +37,24 @@ final class CurrentActivityInteractorTests: XCTestCase {
     XCTAssertEqual(currentActivityPresenter.listenerSetCallCount, 1)
   }
   
-  func test_loadData() async {
+  func test_loadData() {
     // Given
+    let expectation = XCTestExpectation()
     let dummyTitle = "DUMMY"
     let dummyActivityLog = ActivityLog(title: dummyTitle)
     activityLogModelStream.updateActivityLog(with: dummyActivityLog)
     
-    // When
+    // When & Then
+    currentActivityPresenter.bindTageViewTitleHandler = {
+      XCTAssertEqual(self.currentActivityPresenter.bindTagViewTitleCallCount, 1)
+      XCTAssertEqual(self.currentActivityPresenter.bindTagViewTitleSetValue, dummyTitle)
+      expectation.fulfill()
+    }
+
+    sut.activate()
     sut.loadData()
-    async let _ = activityLogModelStream.activityLogStream.values
     
-    // Then
-    XCTAssertEqual(currentActivityPresenter.bindTagViewTitleCallCount, 1)
-    XCTAssertEqual(currentActivityPresenter.bindTagViewTitleSetValue, dummyTitle)
+    wait(for: [expectation], timeout: 5)
   }
 
 }

--- a/iTime/Feature/Tests/StartImplTests/TimeLogRunning/CurrentActivity/CurrentActivityInteractorTests.swift
+++ b/iTime/Feature/Tests/StartImplTests/TimeLogRunning/CurrentActivity/CurrentActivityInteractorTests.swift
@@ -1,0 +1,55 @@
+//
+//  CurrentActivityDatePickerInteractorTests.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import XCTest
+import FeatureTestSupports
+import Start
+@testable import StartImpl
+
+final class CurrentActivityInteractorTests: XCTestCase {
+  
+  private var sut: CurrentActivityInteractor!
+  private var currentActivityPresenter: CurrentActivityPresentableSpy!
+  private var currentActivityListener: CurrentActivityListenerSpy!
+  private var activityLogModelStream: ActivityLogModelStream!
+
+  override func setUp() {
+    currentActivityPresenter = CurrentActivityPresentableSpy()
+    currentActivityListener = CurrentActivityListenerSpy()
+    activityLogModelStream = ActivityLogModelStream()
+    sut = CurrentActivityInteractor(
+      presenter: currentActivityPresenter,
+      activityLogModelStream: activityLogModelStream
+    )
+    sut.listener = currentActivityListener
+  }
+  
+  func test_activate() {
+    // When
+    sut.activate()
+    
+    // Then
+    XCTAssertTrue(sut.isActive)
+    XCTAssertEqual(currentActivityPresenter.listenerSetCallCount, 1)
+  }
+  
+  func test_loadData() async {
+    // Given
+    let dummyTitle = "DUMMY"
+    let dummyActivityLog = ActivityLog(title: dummyTitle)
+    activityLogModelStream.updateActivityLog(with: dummyActivityLog)
+    
+    // When
+    sut.loadData()
+    async let _ = activityLogModelStream.activityLogStream.values
+    
+    // Then
+    XCTAssertEqual(currentActivityPresenter.bindTagViewTitleCallCount, 1)
+    XCTAssertEqual(currentActivityPresenter.bindTagViewTitleSetValue, dummyTitle)
+  }
+
+}

--- a/iTime/Feature/Tests/StartImplTests/TimeLogRunning/CurrentTimeTimer/CurrentTimeTimerInteractorTests.swift
+++ b/iTime/Feature/Tests/StartImplTests/TimeLogRunning/CurrentTimeTimer/CurrentTimeTimerInteractorTests.swift
@@ -4,12 +4,13 @@
 //
 //  Created by 이상헌 on 1/2/24.
 //
+import Foundation
 
 import XCTest
 import FeatureTestSupports
 import RIBsTestSupport
 import Entities
-import RxTest
+import RxSwift
 @testable import StartImpl
 
 final class CurrentTimeTimerInteractorTests: XCTestCase {
@@ -44,25 +45,21 @@ final class CurrentTimeTimerInteractorTests: XCTestCase {
     XCTAssertEqual(currentTimerTimePresenter.listenerSetCallCount, 1)
   }
   
-  func test_loadCurrentTime() async throws {
+  func test_loadCurrentTime() {
     // Given
-    let dummyTimerInfo = TimerInfo(
-      lastlyForegroundTrackedDate: Date(),
-      currentDate: Date(),
-      runningTime: 10,
-      startTime: 1
-    )
-    timerInfoModelDataStream.updateTimerInfo(with: dummyTimerInfo)
+    let expectation = XCTestExpectation()
     
-    // When
+    // When & Then
+    currentTimerTimePresenter.currentRunningTimeHandler = {
+      XCTAssertEqual(self.currentTimerTimePresenter.currentRunningTimeCallCount, 1)
+      XCTAssertFalse(self.currentTimerTimePresenter.currentRunningTimeSetValue.isEmpty)
+      expectation.fulfill()
+    }
+    
+    sut.activate()
     sut.loadCurrentTime()
-    
-    // Then
-    async let response = timerInfoModelDataStream.timerInfoModelDataStream.filter { $0 == dummyTimerInfo }.values
-    let result = try await response.first(where: { _ in true })
-    XCTAssertNotNil(result)
-    XCTAssertEqual(currentTimerTimePresenter.currentRunningTimeCallCount, 1)
-    XCTAssertFalse(currentTimerTimePresenter.currentRunningTimeSetValue.isEmpty)
+
+    wait(for: [expectation], timeout: 5)
   }
 
 }

--- a/iTime/Feature/Tests/StartImplTests/TimeLogRunning/CurrentTimeTimer/CurrentTimeTimerInteractorTests.swift
+++ b/iTime/Feature/Tests/StartImplTests/TimeLogRunning/CurrentTimeTimer/CurrentTimeTimerInteractorTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import FeatureTestSupports
 import RIBsTestSupport
 import Entities
-import RxSwift
+import RxTest
 @testable import StartImpl
 
 final class CurrentTimeTimerInteractorTests: XCTestCase {
@@ -20,8 +20,10 @@ final class CurrentTimeTimerInteractorTests: XCTestCase {
   private var currentTimerTimeListener: CurrentTimerTimeListenerSpy!
   private var currentTimerTimeRouter: CurrentTimerTimeRoutingSpy!
   private var timerInfoModelDataStream: TimerInfoModelDataStream!
+  private var scheduler: TestScheduler!
   
   override func setUp() {
+    scheduler = TestScheduler(initialClock: 0)
     currentTimerTimePresenter = CurrentTimerTimePresentableSpy()
     timerInfoModelDataStream = TimerInfoModelDataStream()
     currentTimerTimeRouter = CurrentTimerTimeRoutingSpy(
@@ -31,7 +33,8 @@ final class CurrentTimeTimerInteractorTests: XCTestCase {
     currentTimerTimeListener = CurrentTimerTimeListenerSpy()
     sut = CurrentTimerTimeInteractor(
       presenter: currentTimerTimePresenter,
-      timerInfoModelDataStream: timerInfoModelDataStream
+      timerInfoModelDataStream: timerInfoModelDataStream,
+      observationScheduler: scheduler
     )
     sut.listener = currentTimerTimeListener
     sut.router = currentTimerTimeRouter
@@ -46,20 +49,16 @@ final class CurrentTimeTimerInteractorTests: XCTestCase {
   }
   
   func test_loadCurrentTime() {
-    // Given
-    let expectation = XCTestExpectation()
-    
-    // When & Then
-    currentTimerTimePresenter.currentRunningTimeHandler = {
-      XCTAssertEqual(self.currentTimerTimePresenter.currentRunningTimeCallCount, 1)
-      XCTAssertFalse(self.currentTimerTimePresenter.currentRunningTimeSetValue.isEmpty)
-      expectation.fulfill()
-    }
-    
+    // When
     sut.activate()
     sut.loadCurrentTime()
-
-    wait(for: [expectation], timeout: 5)
+    
+    
+    // Then
+    scheduler.start()
+    
+    XCTAssertEqual(currentTimerTimePresenter.currentRunningTimeCallCount, 1)
+    XCTAssertFalse(currentTimerTimePresenter.currentRunningTimeSetValue.isEmpty)
   }
 
 }

--- a/iTime/Feature/Tests/StartImplTests/TimeLogRunning/CurrentTimeTimer/CurrentTimeTimerInteractorTests.swift
+++ b/iTime/Feature/Tests/StartImplTests/TimeLogRunning/CurrentTimeTimer/CurrentTimeTimerInteractorTests.swift
@@ -1,0 +1,68 @@
+//
+//  CurrentTimeTimerInteractorTests.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import XCTest
+import FeatureTestSupports
+import RIBsTestSupport
+import Entities
+import RxTest
+@testable import StartImpl
+
+final class CurrentTimeTimerInteractorTests: XCTestCase {
+  
+  private var sut: CurrentTimerTimeInteractor!
+  private var currentTimerTimePresenter: CurrentTimerTimePresentableSpy!
+  private var currentTimerTimeListener: CurrentTimerTimeListenerSpy!
+  private var currentTimerTimeRouter: CurrentTimerTimeRoutingSpy!
+  private var timerInfoModelDataStream: TimerInfoModelDataStream!
+  
+  override func setUp() {
+    currentTimerTimePresenter = CurrentTimerTimePresentableSpy()
+    timerInfoModelDataStream = TimerInfoModelDataStream()
+    currentTimerTimeRouter = CurrentTimerTimeRoutingSpy(
+      interactable: InteractableMock(),
+      viewControllable: ViewControllableMock()
+    )
+    currentTimerTimeListener = CurrentTimerTimeListenerSpy()
+    sut = CurrentTimerTimeInteractor(
+      presenter: currentTimerTimePresenter,
+      timerInfoModelDataStream: timerInfoModelDataStream
+    )
+    sut.listener = currentTimerTimeListener
+    sut.router = currentTimerTimeRouter
+  }
+  
+  func test_activate() {
+    // When
+    sut.activate()
+    
+    // Then
+    XCTAssertEqual(currentTimerTimePresenter.listenerSetCallCount, 1)
+  }
+  
+  func test_loadCurrentTime() async throws {
+    // Given
+    let dummyTimerInfo = TimerInfo(
+      lastlyForegroundTrackedDate: Date(),
+      currentDate: Date(),
+      runningTime: 10,
+      startTime: 1
+    )
+    timerInfoModelDataStream.updateTimerInfo(with: dummyTimerInfo)
+    
+    // When
+    sut.loadCurrentTime()
+    
+    // Then
+    async let response = timerInfoModelDataStream.timerInfoModelDataStream.filter { $0 == dummyTimerInfo }.values
+    let result = try await response.first(where: { _ in true })
+    XCTAssertNotNil(result)
+    XCTAssertEqual(currentTimerTimePresenter.currentRunningTimeCallCount, 1)
+    XCTAssertFalse(currentTimerTimePresenter.currentRunningTimeSetValue.isEmpty)
+  }
+
+}

--- a/iTime/Feature/Tests/StartImplTests/TimeLogRunning/TimerOperation/TimerOperationInteractorTests.swift
+++ b/iTime/Feature/Tests/StartImplTests/TimeLogRunning/TimerOperation/TimerOperationInteractorTests.swift
@@ -67,19 +67,24 @@ final class TimerOperationInteractorTests: XCTestCase {
     XCTAssertFalse(timerOperationPresenter.isTimeRunningSetValue)
   }
   
-  func test_didTapStopButton() async throws {
+  func test_didTapStopButton() {
     // Given
+    let expectation = XCTestExpectation()
     let dummyTitle = "foo"
-    let dummyActivityLog = ActivityLog(title: dummyTitle)
+    let dummyActivityLog = ActivityLog(title: dummyTitle, category: .empty)
     activityLogModelStream.updateActivityLog(with: dummyActivityLog)
     
-    // When
-    sut.didTapStopButton()
-    async let _ = activityLogModelStream.activityLogStream.values
+    // When & Then
+    timerOperationListener.detachTimeLogRunningHandler = {
+      XCTAssertEqual(self.timerUsecase.finishCallCount, 1)
+      XCTAssertEqual(self.timerUsecase.activityValue.title, dummyTitle)
+      XCTAssertEqual(self.timerOperationListener.detachTimeLogRunningRIBCallCount, 1)
+      expectation.fulfill()
+    }
     
-    // Then
-    XCTAssertEqual(timerUsecase.finishCallCount, 1)
-    XCTAssertEqual(timerUsecase.activityValue.title, dummyTitle)
-    XCTAssertEqual(timerOperationListener.detachTimeLogRunningRIBCallCount, 1)
+    sut.activate()
+    sut.didTapStopButton()
+
+    wait(for: [expectation], timeout: 5)
   }
 }

--- a/iTime/Feature/Tests/StartImplTests/TimeLogRunning/TimerOperation/TimerOperationInteractorTests.swift
+++ b/iTime/Feature/Tests/StartImplTests/TimeLogRunning/TimerOperation/TimerOperationInteractorTests.swift
@@ -1,0 +1,85 @@
+//
+//  TimerOperationInteractorTests.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+
+import XCTest
+import FeatureTestSupports
+import UsecaseTestSupports
+import RIBsTestSupport
+import Start
+@testable import StartImpl
+
+final class TimerOperationInteractorTests: XCTestCase {
+  
+  private var sut: TimerOperationInteractor!
+  private var timerUsecase: TimerUsecaseMock!
+  private var timerOperationPresenter: TimerOperationPresentableSpy!
+  private var timerOperationListener: TimerOperationListenerSpy!
+  private var timerOperationRouter: TimerOperationRoutingSpy!
+  private var activityLogModelStream: ActivityLogModelStream!
+
+  override func setUp() {
+    timerUsecase = TimerUsecaseMock()
+    timerOperationListener = TimerOperationListenerSpy()
+    timerOperationPresenter = TimerOperationPresentableSpy()
+    timerOperationRouter = TimerOperationRoutingSpy(
+      interactable: InteractableMock(),
+      viewControllable: ViewControllableMock()
+    )
+    activityLogModelStream = ActivityLogModelStream()
+    sut = TimerOperationInteractor(
+      presenter: timerOperationPresenter,
+      timerUsecase: timerUsecase,
+      activityLogModelStream: activityLogModelStream
+    )
+    sut.listener = timerOperationListener
+    sut.router = timerOperationRouter
+  }
+  
+  func test_activate() {
+    // When
+    sut.activate()
+    
+    // Then
+    XCTAssertEqual(timerOperationPresenter.listenerSetCallCount, 1)
+  }
+  
+  func test_didTapStartButton() {
+    // When
+    sut.didTapStartButton()
+    
+    // Then
+    XCTAssertEqual(timerUsecase.startCallCount, 1)
+    XCTAssertEqual(timerOperationPresenter.isTimeRunningCallCount, 1)
+    XCTAssertTrue(timerOperationPresenter.isTimeRunningSetValue)
+  }
+  
+  func test_didTapPauseButton() {
+    // When
+    sut.didTapPauseButton()
+    
+    // Then
+    XCTAssertEqual(timerUsecase.suspendCallCount, 1)
+    XCTAssertEqual(timerOperationPresenter.isTimeRunningCallCount, 1)
+    XCTAssertFalse(timerOperationPresenter.isTimeRunningSetValue)
+  }
+  
+  func test_didTapStopButton() async throws {
+    // Given
+    let dummyTitle = "foo"
+    let dummyActivityLog = ActivityLog(title: dummyTitle)
+    activityLogModelStream.updateActivityLog(with: dummyActivityLog)
+    
+    // When
+    sut.didTapStopButton()
+    async let _ = activityLogModelStream.activityLogStream.values
+    
+    // Then
+    XCTAssertEqual(timerUsecase.finishCallCount, 1)
+    XCTAssertEqual(timerUsecase.activityValue.title, dummyTitle)
+    XCTAssertEqual(timerOperationListener.detachTimeLogRunningRIBCallCount, 1)
+  }
+}

--- a/iTime/ProxyPackage/Sources/RIBsTestSupport/InteractableMock.swift
+++ b/iTime/ProxyPackage/Sources/RIBsTestSupport/InteractableMock.swift
@@ -1,0 +1,29 @@
+//
+//  File.swift
+//  
+//
+//  Created by 이상헌 on 1/2/24.
+//
+import RxSwift
+
+import RIBs
+
+open class InteractableMock: Interactable {
+  public var activateCallCount: Int = 0
+  public func activate() {
+    activateCallCount += 1
+  }
+  
+  public var deactivateCallCount: Int = 0
+  public func deactivate() {
+    deactivateCallCount += 1
+  }
+  
+  public var isActive: Bool { (try? isActiveSubject.value()) ?? false }
+  
+  public var isActiveStream: RxSwift.Observable<Bool> { isActiveSubject.asObservable() }
+  
+  public let isActiveSubject = BehaviorSubject(value: false)
+  
+  public init() {}
+}


### PR DESCRIPTION
<br>

## Key Changes 🔑


- TimeLogRunning 하위립들 테스트 추가

<br>


## To Reviewers 🙏
- CurrentTimerTimeInteractor -
```
func loadCurrentTime() {
    timerInfoModelDataStream.timerInfoModelDataStream
      .map(\.runningTime)
      .observe(on: MainScheduler.asyncInstance)
      .subscribe(with: self) { owner, time in
        owner.presenter.currentRunningTime(owner.timeString(time)) // 문제의 타겟 Method
      }
      .disposeOnDeactivate(interactor: self)
  }
  
  private func timeString(_ time: Int) -> String {
      let hours = time / 3600
      let minutes = time / 60 % 60
      let seconds = time % 60
      return String(format:"%02i:%02i:%02i", hours, minutes, seconds)
  }
```

subscription안에 메소드를 테스트 할 방법을 계속 찾다가.. 여러가지 방법을 거쳐
expectation을 쓰게 되었습니다. 다만 현재 구현에서는 ModelStream 자체의 default값으로 subscription과 동시에 값이 날라오기 때문에
less flakey 하긴 합니다만.. (분명 더 좋은 방법들이 있을것 같아서 계속 찾아보겠습니다.)
